### PR TITLE
Install the google-api-client gem

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,7 @@ chef_gem "fog" do
   action :install
 end
 
+chef_gem 'google-api-client'
 chef_gem 'uuidtools'
 chef_gem 'multi_json'
 


### PR DESCRIPTION
As of revision `d801b27`, the Fog project requires the `google-api-client` gem to be installed in order to work with Google Compute Engine. This PR installs this gem in addition to fog with the `gce::default` cookbook is included.
