### PR TITLE
add new resource for attaching an IP to an instance

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 default['gce']['api_version'] = "v1"
-default['gce']['fog_version'] = "1.22.1"
+default['gce']['fog_version'] = "1.28.0"

--- a/libraries/gce.rb
+++ b/libraries/gce.rb
@@ -28,11 +28,17 @@ module Google
         :provider => 'google',
         :google_project => new_resource.project_id,
         :google_client_email => new_resource.client_email,
-        :google_key_location => new_resource.key_location,
         :app_name => "#{run_context.cookbook_collection[cookbook_name].metadata.name}-cookbook",
         :app_version => run_context.cookbook_collection[cookbook_name].metadata.version
       }
-
+      
+      # allow use of json key string or key file
+      if new_resource.json_key
+        options.merge!(:google_json_key_string => new_resource.json_key) 
+      else
+        options.merge!(:google_key_location => new_resource.key_location) 
+      end
+      
       @@gce = Fog::Compute.new(options)
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,5 +18,5 @@ maintainer_email  "paulrossman@google.com"
 license           "Apache 2.0"
 description       "LWRPs for managing GCE resources"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "0.5.0"
+version           "0.5.1"
 recipe            "gce", "Installs the fog gem and other dependencies"

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,5 +18,5 @@ maintainer_email  "paulrossman@google.com"
 license           "Apache 2.0"
 description       "LWRPs for managing GCE resources"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "0.4.0"
+version           "0.5.0"
 recipe            "gce", "Installs the fog gem and other dependencies"

--- a/providers/ip.rb
+++ b/providers/ip.rb
@@ -1,0 +1,51 @@
+include Google::Gce
+action :assign do
+  begin
+    raise "Missing Instance ID attribute" unless new_resource.server
+    raise "Missing IP Name attribute" unless new_resource.name
+    raise "Missing project attribute" unless new_resource.project_id
+    raise "Missing client email attribute" unless new_resource.client_email
+    raise "Missing json key attribute" unless new_resource.json_key
+
+    
+    # see Fog/Compute/Google/Real
+    # http://www.rubydoc.info/github/fog/fog/Fog/Compute/Google/Real#add_server_access_config-instance_method
+    # http://www.rubydoc.info/github/fog/fog/Fog/Compute/Google/Real#delete_server_access_config-instance_method
+    Chef::Log.info ("Attempting to replace static ip. ")
+        
+    Timeout::timeout(new_resource.timeout) do
+      server = gce.servers.get(new_resource.server)
+      address = gce.addresses.get(new_resource.name,new_resource.region)
+ 
+      options={
+        :name=>"External NAT", 
+        :address=>address.address
+      } #options for adding access config
+  
+      if server.network_interfaces[0].has_key?("accessConfigs")
+        Chef::Log.info "Deleting access_config for 'nic0'"
+        gce.delete_server_access_config(server.name,server.zone,'nic0')
+
+      end
+       
+      while (server.network_interfaces[0].has_key?("accessConfigs"))
+        Chef::Log.info 'Waiting for access_config to delete'
+        sleep 20
+        server.reload
+      end
+
+      gce.add_server_access_config(server.name,server.zone,'nic0',options)
+      sleep 30 # wait for service to update
+      server = server.reload
+
+      while (server.network_interfaces[0].has_key?("accessConfigs") and 
+            server.network_interfaces[0]["accessConfigs"][0]["natIP"]!= address.address)
+        Chef::Log.info "Waiting for  IP '#{static_ip}' to be added"
+        sleep 20
+        server.reload
+      end
+    end
+  rescue Timeout::Error
+    raise "Timed out waiting to assign static IP after #{new_resource.timeout} seconds"
+  end
+end

--- a/providers/ip.rb
+++ b/providers/ip.rb
@@ -27,36 +27,38 @@ action :assign do
       if  server.network_interfaces[0].has_key?("accessConfigs") && 
           server.network_interfaces[0]["accessConfigs"][0]["natIP"] == address.address
         Chef::Log.info "Server #{server.name} already has Static IP #{address.address}"
-        exit 
-      end
+        
+      else
+   
       
-      if server.network_interfaces[0].has_key?("accessConfigs")
-        Chef::Log.info "Deleting access_config for 'nic0'"
-        access_config =  server.network_interfaces[0]["accessConfigs"][0]["name"]
-        delete_options={
-          access_config: access_config
-        }
-        gce.delete_server_access_config(server.name,server.zone,'nic0',delete_options)
+        if server.network_interfaces[0].has_key?("accessConfigs")
+          Chef::Log.info "Deleting access_config for 'nic0'"
+          access_config =  server.network_interfaces[0]["accessConfigs"][0]["name"]
+          delete_options={
+            access_config: access_config
+          }
+          gce.delete_server_access_config(server.name,server.zone,'nic0',delete_options)
 
-      end
+        end
        
-      while (server.network_interfaces[0].has_key?("accessConfigs"))
-        Chef::Log.info 'Waiting for access_config to delete'
-        Chef::Log.debug "server.network_interfaces[0]: #{server.network_interfaces[0]}"
-        sleep 20
-        server = server.reload
-      end
+        while (server.network_interfaces[0].has_key?("accessConfigs"))
+          Chef::Log.info 'Waiting for access_config to delete'
+          Chef::Log.debug "server.network_interfaces[0]: #{server.network_interfaces[0]}"
+          sleep 20
+          server = server.reload
+        end
 
-      gce.add_server_access_config(server.name,server.zone,'nic0',options)
-      Chef::Log.debug "Added server access_config"
-      sleep 30
-      server = server.reload
+        gce.add_server_access_config(server.name,server.zone,'nic0',options)
+        Chef::Log.debug "Added server access_config"
+        sleep 30
+        server = server.reload
       
   
-      while !server.network_interfaces[0].has_key?("accessConfigs")
-        Chef::Log.info "Waiting for access_config to be added"
-        sleep 10
-        server = server.reload
+        while !server.network_interfaces[0].has_key?("accessConfigs")
+          Chef::Log.info "Waiting for access_config to be added"
+          sleep 10
+          server = server.reload
+        end
       end
     end
   rescue Timeout::Error

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,10 @@ chef_gem "fog" do
   action :install
 end
 
+chef_gem "activesupport" do
+  version '~> 4.0.0'
+  action :install
+end
 chef_gem 'google-api-client'
 chef_gem 'uuidtools'
 chef_gem 'multi_json'

--- a/resources/ip.rb
+++ b/resources/ip.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: gce
+
+# resources
+attribute :name, :kind_of => [String], :default => nil
+attribute :server, :kind_of => [String], :default => nil
+attribute :region, :kind_of => [String], :default => nil
+attribute :project_id, :kind_of => [String], :default => nil
+attribute :client_email, :kind_of => [String], :default => nil
+attribute :json_key, :kind_of => [String], :default => nil
+attribute :timeout, :kind_of => [Integer], :default => 300
+
+actions :assign


### PR DESCRIPTION
allow use of json_key_string for authentication with api
update fog version to support json_key_string
force activersupport gem version to 4.0, new versions are not compatible with fog json dependency
bump version
