### PR TITLE
Fix various bugs and add new functionality.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 default['gce']['api_version'] = "v1"
-default['gce']['fog_version'] = "1.22.1"
+default['gce']['fog_version'] = "1.35.0"
+default['gce']['google-api-client_version'] = "0.8.6"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,12 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-chef_gem "fog" do
+apt_package 'build-essential' do
+end.run_action(:install)
+
+apt_package 'patch' do
+end.run_action(:install)
+
+apt_package 'ruby-dev' do
+end.run_action(:install)
+
+apt_package 'zlib1g-dev' do
+end.run_action(:install)
+
+apt_package 'liblzma-dev' do
+end.run_action(:install)
+
+chef_gem 'fog' do
   version node['gce']['fog_version']
-  action :install
+  compile_time true
 end
 
-chef_gem 'google-api-client'
+chef_gem 'google-api-client' do
+  version node['gce']['google-api-client_version']
+  compile_time true
+end
+
+chef_gem 'fog-google' do
+  compile_time true
+end
+
 chef_gem 'uuidtools'
 chef_gem 'multi_json'
 


### PR DESCRIPTION
* default.rb now installs packages that are required for installing nokogiri, a dependency of the 'fog' gem.
* bumped the fog_version to the latest supported.
* Install a fixed version of the 'google-api-client' and 'fog-google' gems, required to use GCP.
* Improved :attach and :create actions so they now only attempt to converge if they aren't in a converged state.